### PR TITLE
Add prop withCredentials on the XMLHttpRequest

### DIFF
--- a/docs/props.md
+++ b/docs/props.md
@@ -19,6 +19,7 @@ The following props can be passed to `Dropzone`.
 | validate | func | | generic validation function called after file is prepared; receives __fileWithMeta__ object; should return falsy value if validation succeeds; should return truthy value if validation fails, which sets __meta.status__ to __'error_validation'__, and sets __meta.validationError__ to the returned value |
 | autoUpload | bool | `true` | pass false to prevent file from being uploaded automatically; sets __meta.status__ to __'ready'__ (instead of __'getting_upload_params'__) after file is prepared and validated; you can call __fileWithMeta.restart__ whenever you want to initiate file upload |
 | timeout | number | | pass an integer to make upload time out after this many ms; if upload times out, onChangeStatus is invoked with value __'exception_upload'__ |
+| withCredentials | number | | Set to send credentials such as cookies |
 | initialFiles | `File[]` | | add these files to dropzone when it mounts, without any user interaction; see here for an [example of creating and uploading a file from a data URL](https://react-dropzone-uploader.js.org/docs/examples#initial-file-from-data-url) |
 
 

--- a/src/Dropzone.js
+++ b/src/Dropzone.js
@@ -316,6 +316,7 @@ class Dropzone extends React.Component {
 
     formData.append('file', fileWithMeta.file)
     if (this.props.timeout) xhr.timeout = this.props.timeout
+    if (this.props.withCredentials) xhr.withCredentials = true
     xhr.send(body || formData)
     fileWithMeta.xhr = xhr
     fileWithMeta.meta.status = 'uploading'
@@ -508,6 +509,7 @@ Dropzone.propTypes = {
 
   autoUpload: PropTypes.bool,
   timeout: PropTypes.number,
+  withCredentials: PropTypes.bool,
 
   initialFiles: PropTypes.arrayOf(PropTypes.any),
 


### PR DESCRIPTION
Add the possibility to set withCredentials on the XMLHttpRequest object before send.
If the upload path is behind cookie login
