### PR TITLE
Edge does not support Element.scroll()

### DIFF
--- a/src/Dropzone.tsx
+++ b/src/Dropzone.tsx
@@ -363,7 +363,8 @@ class Dropzone extends React.Component<IDropzoneProps, { active: boolean; dragge
   handleFiles = (files: File[]) => {
     files.forEach((f, i) => this.handleFile(f, `${new Date().getTime()}-${i}`))
     const { current } = this.dropzone
-    if (current) setTimeout(() => current.scroll({ top: current.scrollHeight, behavior: 'smooth' }), 150)
+    if (current && typeof current.scroll === "function")
+      setTimeout(() => current.scroll({ top: current.scrollHeight, behavior: 'smooth' }), 150)
   }
 
   handleFile = async (file: File, id: string) => {


### PR DESCRIPTION
Neither does IE. I decided not to include any polyfills because this scrolling into view is not critical to the functionality of the component. But crashing is pretty detrimental to the whole application.