### PR TITLE
Fix crash on Safari

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,5 +109,5 @@ export const getFilesFromEvent = (
     items = event.target.files
   }
 
-  return Array.prototype.slice.call(items)
+  return Array.prototype.slice.call(items || [])
 }


### PR DESCRIPTION
The default implementation of getFilesFromEvent() does not work on Safari. Neither of the conditions is true, `items` is not set and remains null, which causes the `Array.prototype.slice.call()` to throw an exception.

It seems to be just fine though to return an empty array in the drag enter / over events.