### PR TITLE
delay error_upload state transition until xhr done

### DIFF
--- a/src/Dropzone.tsx
+++ b/src/Dropzone.tsx
@@ -537,7 +537,7 @@ class Dropzone extends React.Component<IDropzoneProps, { active: boolean; dragge
         this.forceUpdate()
       }
 
-      if (xhr.status >= 400 && fileWithMeta.meta.status !== 'error_upload') {
+      if (xhr.readyState === 4 && xhr.status >= 400 && fileWithMeta.meta.status !== 'error_upload') {
         fileWithMeta.meta.status = 'error_upload'
         this.handleChangeStatus(fileWithMeta)
         this.forceUpdate()


### PR DESCRIPTION
I use JSON.parse(xhr.responseText) to get error information from the server response when the upload fails.  

To achieve this I currently need the following hack in my custom Preview component

```
            // hack to make the dropzone uploader refresh once the xhr is completed.  In the case of error_upload this doesn't happen since the error_upload status is setup based on the readystate 2 (headers) not 4 (done)
            if (xhr && !xhr._drivenow_patched) {
                xhr._drivenow_patched = true
                xhr.addEventListener('readystatechange', () => {
                    // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readyState
                    if (xhr.readyState === 4) {
                        this.dropzoneRef.current.forceUpdate()
                    }
                })
            }
```