### PR TITLE
fix Property 'status' does not exist on type '{}'

### DIFF
--- a/src/Dropzone.tsx
+++ b/src/Dropzone.tsx
@@ -321,7 +321,7 @@ class Dropzone extends React.Component<IDropzoneProps, { active: boolean; dragge
     if (!this.props.onChangeStatus) return
     const { meta = {} } = this.props.onChangeStatus(fileWithMeta, fileWithMeta.meta.status, this.files) || {}
     if (meta) {
-      delete meta.status
+      delete meta['status']
       fileWithMeta.meta = { ...fileWithMeta.meta, ...meta }
       this.forceUpdate()
     }


### PR DESCRIPTION
We included es2018 into the libs, but it didn't work. Is there something I am missing. As an alternative I found the solution you can see in this pull request. 

Just in case: This is my package.json: 

```JSON
{
  "name": "sp-fx-my-web-part",
  "version": "0.0.0",
  "private": true,
  "engines": {
    "node": ">=0.10.0"
  },
  "scripts": {
    "build": "gulp bundle",
    "clean": "gulp clean",
    "test": "gulp test"
  },
  "dependencies": {
    "@fortawesome/fontawesome-svg-core": "^1.2.25",
    "@fortawesome/free-solid-svg-icons": "^5.11.2",
    "@fortawesome/react-fontawesome": "^0.1.5",
    "@microsoft/sp-core-library": "1.9.1",
    "@microsoft/sp-lodash-subset": "1.9.1",
    "@microsoft/sp-office-ui-fabric-core": "1.9.1",
    "@microsoft/sp-webpart-base": "1.9.1",
    "@types/es6-promise": "0.0.33",
    "@types/react": "16.8.8",
    "@types/react-dom": "16.8.3",
    "@types/webpack-env": "1.13.1",
    "@uifabric/file-type-icons": "^7.1.0",
    "axios": "^0.19.0",
    "memoize-one": "^5.1.1",
    "moment": "^2.24.0",
    "office-ui-fabric-react": "6.189.2",
    "react": "16.8.5",
    "react-dom": "16.8.5",
    "react-dropzone-uploader": "2.11.0",
    "react-moment": "^0.9.2",
    "react-responsive-modal": "^4.0.1",
    "webfontloader": "^1.6.28"
  },
  "resolutions": {
    "@types/react": "16.8.8"
  },
  "devDependencies": {
    "@microsoft/sp-build-web": "1.9.1",
    "@microsoft/sp-module-interfaces": "1.9.1",
    "@microsoft/sp-tslint-rules": "1.9.1",
    "@microsoft/sp-webpart-workbench": "1.9.1",
    "@microsoft/rush-stack-compiler-3.3": "0.3.5",
    "@types/chai": "3.4.34",
    "@types/mocha": "2.2.38",
    "ajv": "~5.2.2",
    "gulp": "~3.9.1"
  }
}
```

This is my Tsconfig.json: 
```JSON
{
  "extends": "./node_modules/@microsoft/rush-stack-compiler-3.3/includes/tsconfig-web.json",
  "compilerOptions": {
    "target": "es6",
    "forceConsistentCasingInFileNames": true,
    "module": "esnext",
    "moduleResolution": "node",
    "jsx": "react",
    "declaration": true,
    "sourceMap": true,
    "experimentalDecorators": true,
    "skipLibCheck": true,
    "outDir": "lib",
    "inlineSources": false,
    "strictNullChecks": false,
    "noUnusedLocals": false,
    "allowSyntheticDefaultImports": true,
    "typeRoots": [
      "./node_modules/@types",
      "./node_modules/@microsoft"
    ],
    "types": [
      "es6-promise",
      "webpack-env"
    ],
    "lib": [
      "es6",
      "es2018",
      "dom",
      "es2015.collection"
    ]
  },
  "include": [
    "src/**/*.ts"
  ],
  "exclude": [
    "node_modules",
    "lib"
  ]
}

```
