### PR TITLE
Fix Strict Null Checking TS issue

### DIFF
--- a/src/Dropzone.tsx
+++ b/src/Dropzone.tsx
@@ -630,7 +630,7 @@ class Dropzone extends React.Component<IDropzoneProps, { active: boolean; dragge
     const SubmitButton = SubmitButtonComponent || SubmitButtonDefault
     const Layout = LayoutComponent || LayoutDefault
 
-    let previews = null
+    let previews: JSX.Element[] | null = null
     if (PreviewComponent !== null) {
       previews = files.map(f => {
         return (


### PR DESCRIPTION
TS does not accept type widening in the strict null checking mode. Setting wide enough type to previews in advance.