### PR TITLE
Align with new stricter TypeScript error typing

### DIFF
--- a/src/Dropzone.tsx
+++ b/src/Dropzone.tsx
@@ -500,7 +500,7 @@ class Dropzone extends React.Component<IDropzoneProps, { active: boolean; dragge
     let params: IUploadParams | null = null
     try {
       params = await getUploadParams(fileWithMeta)
-    } catch (e) {
+    } catch (e: any) {
       console.error('Error Upload Params', e.stack)
     }
     if (params === null) return


### PR DESCRIPTION
TypeScript now has the flag useUnknownInCatchVariables set to true by default.

https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables

This causes importing Dropzone types to fail in projects using the default (or explictly true). Fix is to revert to the current behavior by assuming any explicitly.