### PR TITLE
added fix for safari unhandled error onDragEvents

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,5 +109,7 @@ export const getFilesFromEvent = (
     items = event.target.files
   }
 
+  if(!items) return []
+
   return Array.prototype.slice.call(items)
 }


### PR DESCRIPTION
Keep getting this error in Sentry using an iPad with Safari - ```Unhandled
null is not an object```. Submitting a check for null in the utils.ts file on line 112.